### PR TITLE
WillDoの新規作成画面の実装

### DIFF
--- a/WillDo/App/ContentView.swift
+++ b/WillDo/App/ContentView.swift
@@ -16,22 +16,28 @@ struct ContentView: View {
     var body: some View {
         TabView(selection: $selectedTab) {
             WillDoListView()
-               .tabItem {
-                   Label("WillDo", systemImage: "list.bullet")
-               }
-               .tag(0)
+                .tabItem {
+                    Label("WillDo", systemImage: "list.bullet")
+                }
+                .tag(0)
+            
+            CreateWillDo()
+                .tabItem {
+                    Label("作成", systemImage: "plus")
+                }
+                .tag(1)
 
-           CalendarView()
-               .tabItem {
-                   Label("カレンダー", systemImage: "calendar")
-               }
-               .tag(1)
+            CalendarView()
+                .tabItem {
+                    Label("カレンダー", systemImage: "calendar")
+                }
+                .tag(2)
 
-           AnalyzeView()
-               .tabItem {
-                   Label("分析", systemImage: "chart.bar")
-               }
-               .tag(2)
+            AnalyzeView()
+                .tabItem {
+                    Label("分析", systemImage: "chart.bar")
+                }
+                .tag(3)
         }
     }
 

--- a/WillDo/Views/CreateNew/CreateWillDo.swift
+++ b/WillDo/Views/CreateNew/CreateWillDo.swift
@@ -232,14 +232,6 @@ struct SelectableWillDoView: View {
                 }
             }
             .contentShape(Rectangle())
-            .onTapGesture {
-                if isSelected {
-                    selectParent(nil)
-                }
-                else {
-                    selectParent(item.willDo)
-                }
-            }
 
             // 進捗バー（status に応じて）
             ProgressView(value: item.willDo.status.progress)
@@ -257,6 +249,14 @@ struct SelectableWillDoView: View {
         .padding(.vertical, 4)
         .background(isSelected ? Color.blue.opacity(0.1) : Color.clear)
         .cornerRadius(8)
+        .onTapGesture {
+            if isSelected {
+                selectParent(nil)
+            }
+            else {
+                selectParent(item.willDo)
+            }
+        }
     }
 
     private func formatted(date: Date) -> String {
@@ -276,39 +276,6 @@ struct SelectableWillDoView: View {
             return .green
         case .none:
             return .gray
-        }
-    }
-}
-
-struct WillDoFormView: View {
-    let parentWillDo: WillDo?
-    @Environment(\.presentationMode) var presentationMode
-    
-    var body: some View {
-        NavigationView {
-            VStack {
-                if let parent = parentWillDo {
-                    Text("親WillDo: \(parent.content)")
-                        .font(.largeTitle)
-                        .fontWeight(.bold)
-                        .padding()
-                } else {
-                    Text("新規WillDoを作成")
-                        .font(.largeTitle)
-                        .fontWeight(.bold)
-                        .padding()
-                }
-                Divider()
-                
-                // 中身は後で作成
-                
-                Spacer()
-            }
-            .navigationBarItems(
-                leading: Button("キャンセル") {
-                    presentationMode.wrappedValue.dismiss()
-                }
-            )
         }
     }
 }

--- a/WillDo/Views/CreateNew/WillDoFormView.swift
+++ b/WillDo/Views/CreateNew/WillDoFormView.swift
@@ -1,0 +1,209 @@
+import SwiftUI
+
+struct WillDoFormView: View {
+    let parentWillDo: WillDo?
+    @Environment(\.presentationMode) var presentationMode
+    
+    // フォームの状態管理
+    @State private var content: String = ""
+    @State private var category: String = ""
+    @State private var goalAt: Date? = nil
+    @State private var hasGoal: Bool = false
+    @State private var selectedWeight: Weight? = nil
+    @State private var selectedPriority: Priority? = nil
+    @State private var memoText: String = ""
+    @State private var motivation: Double = 50
+    
+    var body: some View {
+        NavigationView {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 20) {
+                    // ヘッダー
+                    VStack(alignment: .leading, spacing: 8) {
+                        if let parent = parentWillDo {
+                            Text("親WillDo: \(parent.content)")
+                                .font(.headline)
+                                .foregroundColor(.secondary)
+                            Divider()
+                        }
+                    }
+                    .padding(.horizontal)
+                    
+                    VStack(alignment: .leading, spacing: 24) {
+                        // タイトル（content）
+                        VStack(alignment: .leading, spacing: 8) {
+                            Text("タイトル")
+                                .font(.headline)
+                            TextField("\(parentWillDo == nil ? "やりたい" : "やる")ことを入力してください", text: $content)
+                                .textFieldStyle(RoundedBorderTextFieldStyle())
+                        }
+                        
+                        // カテゴリー
+                        VStack(alignment: .leading, spacing: 8) {
+                            Text("カテゴリー")
+                                .font(.headline)
+                            TextField("例: 勉強、健康、趣味", text: $category)
+                                .textFieldStyle(RoundedBorderTextFieldStyle())
+                        }
+                        
+                        // 目標時間
+                        HStack {
+                            Text("目標時間")
+                                .font(.headline)
+                            if hasGoal {
+                                DatePicker(
+                                    "",
+                                    selection: Binding(
+                                        get: { goalAt ?? Date() },
+                                        set: { goalAt = $0 }
+                                    ),
+                                    displayedComponents: [.date, .hourAndMinute]
+                                )
+                                .datePickerStyle(CompactDatePickerStyle())
+                                .environment(\.locale, Locale(identifier: "ja_JP"))
+                                .onChange(of: hasGoal) {
+                                    if !hasGoal {
+                                        goalAt = nil
+                                    } else if goalAt == nil {
+                                        goalAt = Date()
+                                    }
+                                }
+                            } else {
+                                Spacer()
+                            }
+                            Toggle(isOn: $hasGoal) {
+                                EmptyView()
+                            }
+                            .labelsHidden()
+                        }
+                        .frame(height: 32)
+                        
+                        // モチベーション
+                        HStack {
+                            Text("モチベーション：\(Int(motivation))")
+                                .font(.headline)
+                                .frame(width: 160, alignment: .leading)
+                            Slider(value: $motivation, in: 0...100, step: 1)
+                                .accentColor(.blue)
+                        }
+                        
+                        HStack(spacing: 8) {
+                            // 重要度（Weight）
+                            HStack {
+                                Text("重要度")
+                                    .font(.headline)
+                                Spacer()
+                                Picker("重要度", selection: $selectedWeight) {
+                                    Text("選択なし").tag(Weight?.none)
+                                    ForEach(Weight.allCases, id: \.self) { weight in
+                                        Text(weight.label).tag(weight as Weight?)
+                                    }
+                                }
+                                .pickerStyle(MenuPickerStyle())
+                            }
+                            
+                            // 優先度（Priority）
+                            HStack {
+                                Text("優先度")
+                                    .font(.headline)
+                                Spacer()
+                                Picker("優先度", selection: $selectedPriority) {
+                                    Text("選択なし").tag(Priority?.none)
+                                    ForEach(Priority.allCases, id: \.self) { priority in
+                                        Text(priority.label).tag(priority as Priority?)
+                                    }
+                                }
+                                .pickerStyle(MenuPickerStyle())
+                            }
+                        }
+                        
+                        // メモ
+                        VStack(alignment: .leading, spacing: 8) {
+                            Text("メモ")
+                                .font(.headline)
+                            
+                            ZStack(alignment: .topLeading) {
+                                TextEditor(text: $memoText)
+                                    .frame(minHeight: 100)
+                                    .padding(4)
+                                    .background(Color(.systemGray6))
+                                    .cornerRadius(8)
+                                
+                                if memoText.isEmpty {
+                                    Text("自由にメモを記述してください...")
+                                        .foregroundColor(.secondary)
+                                        .padding(.horizontal, 8)
+                                        .padding(.vertical, 12)
+                                        .allowsHitTesting(false)
+                                }
+                            }
+                        }
+                        
+                        // 作成ボタン
+                        Button(action: createWillDo) {
+                            Text("WillDoを作成")
+                                .font(.headline)
+                                .foregroundColor(.white)
+                                .frame(maxWidth: .infinity)
+                                .padding()
+                                .background(content.isEmpty ? Color.gray : Color.blue)
+                                .cornerRadius(10)
+                        }
+                        .disabled(content.isEmpty)
+                        
+                    }
+                    .padding(.horizontal)
+                }
+            }
+            .navigationTitle(parentWillDo != nil ? "子WillDoを作成" : "新規WillDoを作成")
+            .navigationBarItems(
+                leading: Button("キャンセル") {
+                    presentationMode.wrappedValue.dismiss()
+                }
+            )
+        }
+    }
+    
+    private func createWillDo() {
+        // WillDoインスタンスを作成
+        let newWillDo = WillDo(
+            content: content,
+            motivation: Int(motivation),
+            category: category,
+            goalAt: goalAt,
+            weight: selectedWeight,
+            priority: selectedPriority,
+            parentId: parentWillDo?.id
+        )
+        
+        // メモがある場合は追加
+        if !memoText.isEmpty {
+            let memo = Memo(date: Date(), content: memoText)
+            newWillDo.memoList.append(memo)
+        }
+        
+        // TODO: ここでデータ保存処理を実装（今はテストが書いてある）
+        print("作成されたWillDo: \(newWillDo.content)")
+        print("カテゴリー: \(newWillDo.category)")
+        print("モチベーション: \(newWillDo.motivation)")
+        if let goal = newWillDo.goalAt {
+            print("目標時間: \(goal)")
+        }
+        if let weight = newWillDo.weight {
+            print("重要度: \(weight.label)")
+        }
+        if let priority = newWillDo.priority {
+            print("優先度: \(priority.label)")
+        }
+        if !newWillDo.memoList.isEmpty {
+            print("メモ: \(newWillDo.memoList.first?.content ?? "")")
+        }
+        
+        // フォームを閉じる
+        presentationMode.wrappedValue.dismiss()
+    }
+}
+
+#Preview {
+    WillDoFormView(parentWillDo: nil)
+}

--- a/WillDo/Views/CreateWillDo.swift
+++ b/WillDo/Views/CreateWillDo.swift
@@ -1,0 +1,323 @@
+//
+//  CreateWillDo.swift
+//  WillDo
+//
+//  Created by 高野　泰生 on 2025/05/31.
+//
+
+import SwiftUI
+import SwiftData
+
+struct CreateWillDo: View {
+    @Environment(\.modelContext) private var context
+    @Query private var willDos: [WillDo]
+    @State private var expandedIds: Set<String> = []
+    @State private var selectedParentWillDo: WillDo? = nil
+    @State private var isCreatingNewWillDo = false
+    
+    // サンプルデータ（WillDoListViewと同じやつ）
+    let sampleWillDos: [WillDo] = [
+        WillDo(
+            content: "英単語を毎日10個覚える",
+            childWillDos: [
+                WillDo(
+                    content: "単語帳のページ1を覚える",
+                    childWillDos: [
+                        WillDo(
+                            content: "単語帳のページ1を覚える",
+                            motivation: 70,
+                            category: "勉強",
+                            status: .planned,
+                            parentId: "1"
+                        ),
+                        WillDo(
+                            content: "単語帳のページ2を覚える",
+                            motivation: 65,
+                            category: "勉強",
+                            status: .planned,
+                            parentId: "1"
+                        ),
+                        WillDo(
+                            content: "単語帳の復習をする",
+                            motivation: 60,
+                            category: "勉強",
+                            status: .planned,
+                            parentId: "1"
+                        )
+                    ],
+                    motivation: 70,
+                    category: "勉強",
+                    status: .planned,
+                    parentId: "1"
+                ),
+                WillDo(
+                    content: "単語帳のページ2を覚える",
+                    motivation: 65,
+                    category: "勉強",
+                    status: .planned,
+                    parentId: "parent1"
+                ),
+                WillDo(
+                    content: "単語帳の復習をする",
+                    motivation: 60,
+                    category: "勉強",
+                    status: .planned,
+                    parentId: "parent1"
+                )
+            ],
+            motivation: 80,
+            category: "勉強"
+        ),
+        WillDo(
+            content: "健康的な生活習慣を身につける",
+            childWillDos: [
+                WillDo(
+                    content: "早寝早起きをする",
+                    motivation: 75,
+                    category: "健康",
+                    status: .start,
+                    parentId: "parent2"
+                ),
+                WillDo(
+                    content: "毎日運動する",
+                    motivation: 70,
+                    category: "健康",
+                    status: .planned,
+                    parentId: "parent2"
+                )
+            ],
+            motivation: 85,
+            category: "健康"
+        ),
+        WillDo(
+            content: "本を読む",
+            motivation: 60,
+            category: "読書",
+            goalAt: Calendar.current.date(byAdding: .month, value: 1, to: Date()),
+            status: .middle,
+            impression: "読み切ったけどまとめるのが大変だった"
+        )
+    ]
+    
+    var body: some View {
+        NavigationView {
+            VStack {
+                Text("新しいWillDoを作成する場所を選択してください")
+                    .font(.headline)
+                    .padding()
+                
+                List {
+                    ForEach(flattened(sampleWillDos.filter { $0.parentId == nil })) { item in
+                        SelectableWillDoView(
+                            item: item,
+                            isExpanded: expandedIds.contains(item.willDo.id),
+                            isSelected: selectedParentWillDo?.id == item.willDo.id,
+                            toggleExpansion: toggleExpansion,
+                            selectParent: selectParent
+                        )
+                    }
+                }
+                
+                VStack(spacing: 16) {
+                    Button(action: {
+                        selectedParentWillDo = nil
+                        isCreatingNewWillDo = true
+                    }) {
+                        HStack {
+                            Image(systemName: "plus.circle.fill")
+                            Text("新しいWillDoをルートに作成")
+                        }
+                        .foregroundColor(.white)
+                        .frame(maxWidth: .infinity)
+                        .padding()
+                        .background(Color.blue)
+                        .cornerRadius(10)
+                    }
+                    .padding(.horizontal)
+                    
+                    if selectedParentWillDo != nil {
+                        Button(action: {
+                            isCreatingNewWillDo = true
+                        }) {
+                            HStack {
+                                Image(systemName: "plus.circle.fill")
+                                Text("選択したWillDoの子として作成")
+                            }
+                            .foregroundColor(.white)
+                            .frame(maxWidth: .infinity)
+                            .padding()
+                            .background(Color.green)
+                            .cornerRadius(10)
+                        }
+                        .padding(.horizontal)
+                    }
+                }
+                .padding(.bottom)
+            }
+            .navigationTitle("WillDo作成")
+        }
+        .sheet(isPresented: $isCreatingNewWillDo) {
+            WillDoFormView(parentWillDo: selectedParentWillDo)
+        }
+    }
+    
+    func toggleExpansion(id: String) {
+        if expandedIds.contains(id) {
+            expandedIds.remove(id)
+        } else {
+            expandedIds.insert(id)
+        }
+    }
+    
+    func selectParent(_ willDo: WillDo?) {
+        selectedParentWillDo = willDo
+    }
+    
+    func flattened(_ willDos: [WillDo], level: Int = 0) -> [FlattenedWillDo] {
+        var result: [FlattenedWillDo] = []
+
+        for willDo in willDos {
+            result.append(FlattenedWillDo(willDo: willDo, level: level))
+            if expandedIds.contains(willDo.id) {
+                let children = willDo.childWillDos.sorted { $0.createAt < $1.createAt }
+                result += flattened(children, level: level + 1)
+            }
+        }
+
+        return result
+    }
+}
+
+struct SelectableWillDoView: View {
+    let item: FlattenedWillDo
+    let isExpanded: Bool
+    let isSelected: Bool
+    let toggleExpansion: (String) -> Void
+    let selectParent: (WillDo?) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Spacer()
+                    .frame(width: CGFloat(item.level) * 20)
+
+                // 展開アイコン or プレースホルダー
+                if !item.willDo.childWillDos.isEmpty {
+                    Image(systemName: isExpanded ? "chevron.down.circle.fill" : "chevron.right.circle.fill")
+                        .foregroundColor(.blue)
+                        .onTapGesture {
+                            toggleExpansion(item.willDo.id)
+                        }
+                } else {
+                    Image(systemName: "circle")
+                        .opacity(0.5)
+                }
+
+                // 優先度による色付きアイコン
+                Circle()
+                    .fill(colorForPriority(item.willDo.priority))
+                    .frame(width: 10, height: 10)
+
+                // コンテンツ
+                Text(item.willDo.content)
+                    .font(.body)
+                    .padding(.leading, 4)
+
+                Spacer()
+                
+                // 選択インジケーター
+                if isSelected {
+                    Image(systemName: "checkmark.circle.fill")
+                        .foregroundColor(.green)
+                }
+            }
+            .contentShape(Rectangle())
+            .onTapGesture {
+                if isSelected {
+                    selectParent(nil)
+                }
+                else {
+                    selectParent(item.willDo)
+                }
+            }
+
+            // 進捗バー（status に応じて）
+            ProgressView(value: item.willDo.status.progress)
+                .accentColor(item.willDo.status.color)
+                .padding(.leading, CGFloat(item.level) * 20 + 32)
+
+            // 目標日がある場合に表示
+            if let goalDate = item.willDo.goalAt {
+                Text("目標: \(formatted(date: goalDate))")
+                    .font(.caption)
+                    .foregroundColor(.gray)
+                    .padding(.leading, CGFloat(item.level) * 20 + 32)
+            }
+        }
+        .padding(.vertical, 4)
+        .background(isSelected ? Color.blue.opacity(0.1) : Color.clear)
+        .cornerRadius(8)
+    }
+
+    private func formatted(date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .short
+        formatter.locale = Locale(identifier: "ja_JP")
+        return formatter.string(from: date)
+    }
+
+    private func colorForPriority(_ priority: Priority?) -> Color {
+        switch priority {
+        case .high:
+            return .red
+        case .medium:
+            return .orange
+        case .low:
+            return .green
+        case .none:
+            return .gray
+        }
+    }
+}
+
+struct WillDoFormView: View {
+    let parentWillDo: WillDo?
+    @Environment(\.presentationMode) var presentationMode
+    
+    var body: some View {
+        NavigationView {
+            VStack {
+                if let parent = parentWillDo {
+                    Text("親WillDo: \(parent.content)")
+                        .font(.largeTitle)
+                        .fontWeight(.bold)
+                        .padding()
+                } else {
+                    Text("新規WillDoを作成")
+                        .font(.largeTitle)
+                        .fontWeight(.bold)
+                        .padding()
+                }
+                Divider()
+                
+                // 中身は後で作成
+                
+                Spacer()
+            }
+            .navigationBarItems(
+                leading: Button("キャンセル") {
+                    presentationMode.wrappedValue.dismiss()
+                }
+            )
+        }
+    }
+}
+
+#Preview {
+    TabView {
+        CreateWillDo()
+            .tabItem {
+                Label("作成", systemImage: "plus")
+            }
+    }
+}


### PR DESCRIPTION
# 内容
* WillDoを新規に作成するViewを作成
* 作成場所（ルートか既存のWillDoの子か）を選択 → 必要な内容を入力して作成（インスタンスのみ）
# 今後の予定
* インスタンス生成部分にテスト用のコードが書いてあるが、それをデータベースに保存するクラスを呼び出すように変更